### PR TITLE
prepend stylesheet files in layout

### DIFF
--- a/view/layout/admin.phtml
+++ b/view/layout/admin.phtml
@@ -7,17 +7,18 @@
     <?= $this->headMeta()->appendName('viewport', 'width=device-width, initial-scale=1.0') ?>
     <?php
     $this->headLink()
-        ->appendStylesheet('//fonts.googleapis.com/css?family=Open+Sans:400italic,700italic,400,700')
-        ->appendStylesheet($this->basePath('css/midnight/admin-module/normalize.css'))
-        ->appendStylesheet($this->basePath('css/midnight/admin-module/layout.css'))
-        ->appendStylesheet($this->basePath('css/midnight/admin-module/base.css'))
-        ->appendStylesheet($this->basePath('css/midnight/admin-module/forms.css'))
-        ->appendStylesheet($this->basePath('css/midnight/admin-module/ui.css'));
+        ->prependStylesheet($this->basePath('css/midnight/admin-module/ui.css'))
+        ->prependStylesheet($this->basePath('css/midnight/admin-module/forms.css'))
+        ->prependStylesheet($this->basePath('css/midnight/admin-module/base.css'))
+        ->prependStylesheet($this->basePath('css/midnight/admin-module/layout.css'))
+        ->prependStylesheet($this->basePath('css/midnight/admin-module/normalize.css'))
+        ->prependStylesheet('//fonts.googleapis.com/css?family=Open+Sans:400italic,700italic,400,700');
     $this->headScript()
         ->prependFile('//ajax.googleapis.com/ajax/libs/jquery/2.1.0/jquery.min.js')
         ->appendFile($this->basePath('js/midnight/admin-module/ui.js'));
     ?>
     <?= $this->headLink() ?>
+    <?= $this->headStyle() ?>
 </head>
 <body>
 <?= $this->render('layout/admin/banner.phtml') ?>


### PR DESCRIPTION
Because otherwise overwrite stylesheets in views would't work (they're rendered first), so styelsheets in layout are always appended;
add headStyle() for inline styles
